### PR TITLE
Removed dev-requirements installation step

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -76,7 +76,6 @@ do the following::
 	git clone https://github.com/datadotworld/ckanext-datadotworld.git
 	cd ckanext-datadotworld
 	python setup.py develop
-	pip install -r dev-requirements.txt
 	paster datadotworld init -c /config.ini
 
 -----------------


### PR DESCRIPTION
Looks like the dev-requirements were wrapped into the setup script early on in development. This installation step remaining left some confusion because the file no longer exists.